### PR TITLE
Use peer depedency & change support to latest jabby version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "roblox-ts": "^3.0.0",
     "typescript": "^5.7.2"
   },
-  "dependencies": {
-    "@rbxts/jabby": "0.2.0-rc.7",
-    "@rbxts/planck": "0.1.3-rc.0"
+  "peerDependencies": {
+    "@rbxts/jabby": "*",
+    "@rbxts/planck": "*"
   },
   "publishConfig": {
     "access": "public"

--- a/src/init.luau
+++ b/src/init.luau
@@ -90,8 +90,13 @@ function Plugin:build(scheduler: any)
 		end
 	end)
 
-	table.insert(Jabby.public, jabbyScheduler)
-	Jabby.public.updated = true
+	Jabby.register({
+		name = name,
+		applet = Jabby.applets.scheduler,
+		configuration = {
+			scheduler = jabbyScheduler,
+		},
+	})
 end
 
 function Plugin.new()

--- a/src/init.luau
+++ b/src/init.luau
@@ -51,7 +51,7 @@ function Plugin:build(scheduler: any)
 		function(info: SystemsAddRemove)
 			local id = jabbyScheduler:register_system({
 				name = info.system.name,
-				phase = info.system.phase,
+				phase = tostring(info.system.phase),
 			})
 
 			systemToId[info.system.system] = id


### PR DESCRIPTION
This pull will update the dependencies to use peerDependencies so the scripts and this package use the same instance of jabby and jecs and there's also few changes to adapt to jabby's registering system on newer versions and tostringing phase so jabby doesn't error attempting to render a table as text

## Summary by Sourcery

Update dependencies to peer dependencies and adapt to the latest Jabby version, including changes to the registering system and stringifying the system phase.

New Features:
- Adapt to Jabby's new registering system.

Enhancements:
- Use peer dependencies for Jabby and Planck.